### PR TITLE
Seperate lnet config from connect_lustre & make it more configureable

### DIFF
--- a/group_vars-example/all
+++ b/group_vars-example/all
@@ -19,7 +19,6 @@ migrid_repository: https://github.com/ucphhpc/docker-migrid.git     # the github
 migrid_user: mig                            # this is the use on the sever with unique uid/gid
 migrid_encrypt_state: false                 # this is used to set our base expectation for state directory on lustre. That it is only encrypted if specified.
 migrid_decrypt_dir: decrypt_state           # this is the state directory name when encryption is set
-#migrid_state_dir_name: lustate             # the directory name of the state directory. Default lustate
 migrid_docker_compose_preset: docker-compose_dev.erda.dk_full.yml          # link docker-compose to existing compose file if defined. Otherwise you will have to set migrid_docker_compose_custom to what you want to use.
 migrid_docker_compose_file: docker-compose_dev.erda.dk_full.yml # needed ??
 migrid_docker_compose_override: true        # to enable that the docker-compose file will be rendered from template in migrid_baseline role

--- a/install-migrid.yml
+++ b/install-migrid.yml
@@ -19,6 +19,7 @@
     - copy_overlay_files
     - migrid_baseline
     - copy_cert_files
+    - configure_lustre
     - connect_lustre
     - setup_encrypt_state
     - startup_encrypt_state

--- a/roles/configure_lustre/README.md
+++ b/roles/configure_lustre/README.md
@@ -1,0 +1,5 @@
+# Configure Lustre
+
+This role configures a Lustre client to to able to talk to a lnet.
+
+Used by AU only.

--- a/roles/configure_lustre/defaults/main.yml
+++ b/roles/configure_lustre/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# default from AU
+configure_lustre_lnet_networks: tcp1(ens224),tcp2(ens256)

--- a/roles/configure_lustre/tasks/main.yml
+++ b/roles/configure_lustre/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Copy lnet.conf to modprobe.d
+  template:
+    src: lnet.conf.j2
+    dest: /etc/modprobe.d/lnet.conf
+    owner: root
+    group: root
+    mode: "0644"

--- a/roles/configure_lustre/templates/lnet.conf.j2
+++ b/roles/configure_lustre/templates/lnet.conf.j2
@@ -1,0 +1,1 @@
+options lnet networks="{{ configure_lustre_lnet_networks }}"

--- a/roles/connect_lustre/README.md
+++ b/roles/connect_lustre/README.md
@@ -1,0 +1,5 @@
+# connect\_lustre
+
+This role aims to connect the deployed migrid application to a configured lustre filesystem.
+Therefore it can mount the lustre filesystem and link state directory for migrid to it.
+See `defaults/` for variables.

--- a/roles/connect_lustre/defaults/main.yml
+++ b/roles/connect_lustre/defaults/main.yml
@@ -1,2 +1,13 @@
 ---
-migrid_state_dir_name: lustate
+# the name of the symlink in the docker-migrid repo pointing to the state directory
+migrid_connect_lustre_state_link: lustate
+
+# the directory in which all the mountpoints should be created
+migrid_connect_lustre_mount_prefix: /mnt
+
+# wheather or not the the role should actually mount the Lustre filesystem
+# otherwise only the symlink is created
+migrid_connect_lustre_configure_mount: true
+
+# mountoptions for the Lustre filesystem that will be used
+migrid_connect_lustre_mount_options: flock

--- a/roles/connect_lustre/files/lnet.conf
+++ b/roles/connect_lustre/files/lnet.conf
@@ -1,1 +1,0 @@
-options lnet networks="tcp1(ens224),tcp2(ens256)"

--- a/roles/connect_lustre/tasks/main.yml
+++ b/roles/connect_lustre/tasks/main.yml
@@ -1,13 +1,6 @@
 ---
 # deals with creating dirs for mounting lustre
 # depends on migrid-baseline
-- name: Copy lnet.conf to modprobe.d
-  copy:
-    src: lnet.conf
-    dest: /etc/modprobe.d/
-    owner: root
-    group: root
-    mode: "0644"
 
 #FIXME: the strings in migrid_lustre_mount.dest should match up with migrid_lustre_mount_point
 

--- a/roles/connect_lustre/tasks/main.yml
+++ b/roles/connect_lustre/tasks/main.yml
@@ -3,7 +3,6 @@
 # depends on migrid-baseline
 
 #FIXME: the strings in migrid_lustre_mount.dest should match up with migrid_lustre_mount_point
-
 - name: Create directories for lustre mount points
   file:
     path: "{{ migrid_connect_lustre_mount_prefix }}/{{ item.dest }}"
@@ -11,7 +10,7 @@
     group: root
     state: directory
     mode: "0755"
-  loop: "{{ migrid_lustre_mount | selectattr('dest', 'match', migrid_base_type) | list }}"
+  loop: "{{ migrid_lustre_mount | selectattr('dest', 'contains', migrid_base_type) | list }}"
 
 # this will select the drive to be mounted based on the variable migrid_lustre_mount_point
 # it will only mount the one specified in migrid_lustre_mount_point so it cannot mount both 

--- a/roles/connect_lustre/tasks/main.yml
+++ b/roles/connect_lustre/tasks/main.yml
@@ -6,26 +6,27 @@
 
 - name: Create directories for lustre mount points
   file:
-    path: /mnt/{{ item.dest }}
+    path: "{{ migrid_connect_lustre_mount_prefix }}/{{ item.dest }}"
     owner: root
     group: root
     state: directory
     mode: "0755"
-  loop: "{{ migrid_lustre_mount| selectattr('dest', 'match', migrid_base_type)|list }}"
+  loop: "{{ migrid_lustre_mount | selectattr('dest', 'match', migrid_base_type) | list }}"
 
 # this will select the drive to be mounted based on the variable migrid_lustre_mount_point
 # it will only mount the one specified in migrid_lustre_mount_point so it cannot mount both 
 # sites at the same time
 - name: Mount Lustre directory
   mount:
-    path: /mnt/{{ item.dest }}
+    path: "{{ migrid_connect_lustre_mount_prefix }}/{{ item.dest }}"
     src: "{{ item.src }}"
-    opts: flock
+    opts: "{{ migrid_connect_lustre_mount_options }}"
     fstype: lustre
     state: mounted
-  loop: "{{ migrid_lustre_mount| selectattr('dest', 'match', migrid_lustre_mount_point)|list }}"
+  loop: "{{ migrid_lustre_mount | selectattr('dest', 'match', migrid_lustre_mount_point) | list }}"
+  when: migrid_connect_lustre_configure_mount == true
 
-- name: Create dir {{ migrid_state_directory }}
+- name: Create migrid_state_directory ({{ migrid_state_directory }})
   file:
     path: "{{ migrid_state_directory }}"
     owner: "{{ migrid_user }}"
@@ -34,7 +35,7 @@
     mode: "0755"
 
 # encryption stuff
-- name: Create {{ migrid_cipher_directory }} when using encryption
+- name: Create migrid_cipher_directory ({{ migrid_cipher_directory }})
   file:
     path: "{{ migrid_cipher_directory }}"
     owner: "{{ migrid_user }}"
@@ -44,9 +45,9 @@
   when: migrid_encrypt_state==true
 
 # non encryption stuff
-- name: Create shortcut link
+- name: Create link from migrid state to migrid_connect_lustre_state_link ({{ migrid_connect_lustre_state_link }})
   file:
     src: "{{ migrid_state_directory }}"
-    dest: "{{ migrid_root }}/{{ migrid_state_dir_name }}"
+    dest: "{{ migrid_root }}/{{ migrid_connect_lustre_state_link }}"
     state: link
   when: migrid_encrypt_state==false

--- a/roles/copy_cert_files/tasks/main.yml
+++ b/roles/copy_cert_files/tasks/main.yml
@@ -25,11 +25,11 @@
     src: "{{ item.src }}{{ inventory_hostname }}"
     dest: "{{ migrid_certs }}/{{ item.dest }}{{ inventory_hostname }}"
     state: link
-  loop: "{{ migrid_cert_dir_links | default([]) }}"
+  loop: "{{ migrid_cert_dir_links }}"
 
 - name: Create symbolic links for files
   file:
     src: "{{ item.src }}{{ inventory_hostname }}/{{ item.dest }}"
     dest: "{{ migrid_certs }}/{{ item.dest }}"
     state: link
-  loop: "{{ migrid_cert_dir_links | default([]) }}"
+  loop: "{{ migrid_cert_dir_links }}"


### PR DESCRIPTION
This PR splits connect_lustre into `configure_lustre` and `connect_lustre`.

It also make `connect_lustre` more configurable.

I also changed the `selectattr` from `match` to `contains` to create all mountpoints, otherwise it was always skipped.

@Bjarke42 feel free to review, if you're unhappy with a specific commit or line I can of course always change it.