### PR TITLE
Rebuild update status html

### DIFF
--- a/roles/update_status_html/tasks/main.yml
+++ b/roles/update_status_html/tasks/main.yml
@@ -1,7 +1,11 @@
 ---
 # builds that status.html file that shows the deployed versions
 
-- name: get git tag
+#
+# get versions
+#
+
+- name: get local git tag
   delegate_to: localhost
   become: false
   shell:
@@ -14,35 +18,79 @@
 
 - name: register tag
   set_fact:
-    deploy_version: "{{ { 'deploy_version' : result.stdout } }}"
+    deploy_local_version: "{{ { 'deploy_local_version' : result.stdout } }}"
   when: migrid_update_status_deploy_version is defined
+
+- name: get ansible-docker-migrid version
+  delegate_to: localhost
+  become: false
+  shell:
+    cmd: ansible-galaxy collection list | grep ucphhpc.docker_migrid|cut -d" " -f2
+    chdir: ~
+  register: result
+
+- name: register ansible-docker-migrid version
+  set_fact:
+    ansible_docker_migrid_version: "{{ { 'ansible_docker_migrid_version' : result.stdout } }}"
+  when: result.rc==0
+
+#
+# get values from env file
+#
 
 - name: get deployed migrid version
   shell:
     cmd: grep ^MIG_GIT_REV {{ migrid_root }}/.env
-  register: get_deployed_migrid_version
-  ignore_errors: true
+  register: result
 
 - name: register deployed migrid version
   set_fact:
     migrid_git_rev: "{{ { result.stdout.split('=')[0]:result.stdout.split('=')[1] } }}"
-  when: not get_deployed_migrid_version.failed
+  when: result.rc==0
 
-# fixme: is actually anyone using svn anymore?
-- name: get deployed svn version
+- name: get WITH_GIT from env file
   shell:
-    cmd: grep ^MIG_SVN_REV {{ migrid_root }}/.env
+    cmd: grep ^WITH_GIT {{ migrid_root }}/.env
   register: result
-  when: migrid_update_status_subversion is defined
-
-- name: register deployed svn version
+  
+- name: register WITH_GIT
   set_fact:
-    migrid_svn_rev: "{{ { result.stdout.split('=')[0]:result.stdout.split('=')[1] } }}"
-  when: migrid_update_status_subversion is defined
+    migrid_with_git: "{{ { result.stdout.split('=')[0]:result.stdout.split('=')[1] } }}"
+  when: result.rc==0
+
+- name: get MIG_GIT_BRANCH from env file
+  shell:
+    cmd: grep ^MIG_GIT_BRANCH {{ migrid_root }}/.env
+  register: result
+  
+- name: register migrid git branch
+  set_fact:
+    migrid_git_branch: "{{ { result.stdout.split('=')[0]:result.stdout.split('=')[1] } }}"
+  when: result.rc==0
+
+- name: get PREFER_PYTHON3 from env file
+  shell:
+    cmd: grep ^PREFER_PYTHON3 {{ migrid_root }}/.env
+  register: result
+  
+- name: register migrid perfer python3
+  set_fact:
+    migrid_perfer_python3: "{{ { result.stdout.split('=')[0]:result.stdout.split('=')[1] } }}"
+  when: result.rc==0
+
+- name: get ENABLE_GDP from env file
+  shell:
+    cmd: grep ^ENABLE_GDP {{ migrid_root }}/.env
+  register: result
+  
+- name: register enable gdp
+  set_fact:
+    migrid_enable_gdp: "{{ { result.stdout.split('=')[0]:result.stdout.split('=')[1] } }}"
+  when: result.rc==0
 
 - name: update status.html
   copy:
-    content: "{{ deploy_version | combine(migrid_git_rev) | combine(migrid_svn_rev ) | to_json }}"
+    content: "{{ deploy_local_version | ansible_docker_migrid_version | combine(migrid_git_rev) | combine(migrid_with_git) | combine(migrid_git_branch) | combine(migrid_perfer_python3) | combine(migrid_enable_gdp) | to_json }}"
     dest: "{{ migrid_state_directory }}/wwwpublic/status.html"
     owner: "{{ migrid_user }}"
     group: "{{ migrid_user }}"

--- a/roles/update_status_html/tasks/main.yml
+++ b/roles/update_status_html/tasks/main.yml
@@ -29,18 +29,15 @@
     chdir: ~
   register: result
 
-- name: print result
-  debug:
-    msg: " {{ result }}"
-
-- name: print var
-  debug:
-    var: result.rc==0 
-
 - name: register ansible-docker-migrid version
   set_fact:
     ansible_docker_migrid_version: "{{ { 'ansible_docker_migrid_version' : result.stdout } }}"
   when: result.rc==0
+
+- name: print result
+  debug:
+    msg: " {{ ansible_docker_migrid_version }}"
+
 
 #
 # get values from env file

--- a/roles/update_status_html/tasks/main.yml
+++ b/roles/update_status_html/tasks/main.yml
@@ -31,7 +31,7 @@
 
 - name: print result
   debug:
-    msg: result
+    msg: " {{ result }}"
 
 - name: register ansible-docker-migrid version
   set_fact:

--- a/roles/update_status_html/tasks/main.yml
+++ b/roles/update_status_html/tasks/main.yml
@@ -34,11 +34,6 @@
     ansible_docker_migrid_version: "{{ { 'ansible_docker_migrid_version' : result.stdout } }}"
   when: result.rc==0
 
-- name: print result
-  debug:
-    msg: " {{ ansible_docker_migrid_version }}"
-
-
 #
 # get values from env file
 #
@@ -95,7 +90,7 @@
 
 - name: update status.html
   copy:
-    content: "{{ deploy_local_version | ansible_docker_migrid_version | combine(migrid_git_rev) | combine(migrid_with_git) | combine(migrid_git_branch) | combine(migrid_perfer_python3) | combine(migrid_enable_gdp) | to_json }}"
+    content: "{{ deploy_local_version | combine(ansible_docker_migrid_version) | combine(migrid_git_rev) | combine(migrid_with_git) | combine(migrid_git_branch) | combine(migrid_perfer_python3) | combine(migrid_enable_gdp) | to_json }}"
     dest: "{{ migrid_state_directory }}/wwwpublic/status.html"
     owner: "{{ migrid_user }}"
     group: "{{ migrid_user }}"

--- a/roles/update_status_html/tasks/main.yml
+++ b/roles/update_status_html/tasks/main.yml
@@ -33,10 +33,14 @@
   debug:
     msg: " {{ result }}"
 
+- name: print var
+  debug:
+    var: result.rc==0 
+
 - name: register ansible-docker-migrid version
   set_fact:
     ansible_docker_migrid_version: "{{ { 'ansible_docker_migrid_version' : result.stdout } }}"
-  when: result.rc=="0"
+  when: result.rc==0
 
 #
 # get values from env file

--- a/roles/update_status_html/tasks/main.yml
+++ b/roles/update_status_html/tasks/main.yml
@@ -29,6 +29,10 @@
     chdir: ~
   register: result
 
+- name: print result
+  debug:
+    msg: result
+
 - name: register ansible-docker-migrid version
   set_fact:
     ansible_docker_migrid_version: "{{ { 'ansible_docker_migrid_version' : result.stdout } }}"

--- a/roles/update_status_html/tasks/main.yml
+++ b/roles/update_status_html/tasks/main.yml
@@ -36,7 +36,7 @@
 - name: register ansible-docker-migrid version
   set_fact:
     ansible_docker_migrid_version: "{{ { 'ansible_docker_migrid_version' : result.stdout } }}"
-  when: result.rc==0
+  when: result.rc=="0"
 
 #
 # get values from env file


### PR DESCRIPTION
update_status_html is now fixed to work with this way of deploying. 
The info provided has changed to more information. 
example of erda:
`{"deploy_local_version": "v1.5", "ansible_docker_migrid_version": "0.3.0", "MIG_GIT_REV": "6c71d37679f6750faa288365e68f4bc055e953fc", "WITH_GIT": "True", "MIG_GIT_BRANCH": "experimental", "PREFER_PYTHON3": "True", "ENABLE_GDP": "False"}`

The info will be used for submitting issues to migrid developers as well as info for operations about the versions running.