### PR TITLE
remove AU from migrid_overlay + rework on migrid_clean + misc

### DIFF
--- a/group_vars-example/all
+++ b/group_vars-example/all
@@ -10,7 +10,7 @@
 #migrid settings
 migrid_root: /opt/migrid/docker-migrid      # root directory where all the migrid files recides on the server
 ##migrid_auoverlay
-migrid_au_overlay: /opt/migrid/au-overlay   # the au overlay files that are placed ontop of files pulled from docker-migrid repository
+migrid_overlay: /opt/migrid/au-overlay   # the au overlay files that are placed ontop of files pulled from docker-migrid repository
 migrid_certs: "{{ migrid_root }}/certs"     # directory where all certificates recides
 migrid_adm: migadm                          # default user for migrid administrator. Only used on linux file system, not while running migrid
 migrid_adm_gid: 1010                        # gid of migrid_adm user

--- a/group_vars-example/all
+++ b/group_vars-example/all
@@ -29,10 +29,6 @@ migrid_docker_compose_override: true        # to enable that the docker-compose 
 migrid_update_status_deploy_version: true   # if defined will update version
 migrid_update_status_subversion: true       # if defined will update subversion number
 
-# This is used when you have a clean never used server only!!!
-# use on ansible-playbook -e migrid_bootstrap=true 
-# FIXME deprecated will soon be removed
-migrid_bootstrap: false
 # enable further cleaning of the environment
 migrid_cleanup: false
 

--- a/group_vars-example/all
+++ b/group_vars-example/all
@@ -29,10 +29,6 @@ migrid_docker_compose_override: true        # to enable that the docker-compose 
 migrid_update_status_deploy_version: true   # if defined will update version
 migrid_update_status_subversion: true       # if defined will update subversion number
 
-# enable further cleaning of the environment
-migrid_cleanup: false
-
-
 #certificate links
 migrid_cert_dir_links:
     - { src: "MiG/*", dest: "anon." }

--- a/install-migrid.yml
+++ b/install-migrid.yml
@@ -4,8 +4,6 @@
 - name: deploy certificates from vault
   hosts:
     - all
-  vars:
-    migrid_cleanup: true
   gather_facts: true
   become: true
   roles:

--- a/roles/copy_overlay_files/README.md
+++ b/roles/copy_overlay_files/README.md
@@ -1,0 +1,6 @@
+# copy\_overlay\_files
+
+This role copies the deployment specific files like html pages to the remote host.
+For a example directory see [manual-example/](../../manual-example/).
+
+For variables see [defaults/main.yml](defaults/main.yml)

--- a/roles/copy_overlay_files/tasks/main.yaml
+++ b/roles/copy_overlay_files/tasks/main.yaml
@@ -1,8 +1,8 @@
 ---
 # copies overlay files onto server. They are placed in a directory besides migrid
-- name: Create directory for au-overlay
+- name: Create directory for migrid-overlay
   file:
-    path: "{{ migrid_au_overlay }}"
+    path: "{{ migrid_overlay }}"
     owner: "{{ migrid_adm }}"
     group: "{{ migrid_adm }}"
     state: directory
@@ -11,11 +11,11 @@
 - name: copy files from manual/au-overlay to server
   synchronize:
     src: manual/au-overlay/{{ ansible_hostname }}/
-    dest: "{{ migrid_au_overlay }}/{{ ansible_hostname }}/"
+    dest: "{{ migrid_overlay }}/{{ ansible_hostname }}/"
 
 - name: Changer owner on all files
   file:
-    path: "{{ migrid_au_overlay }}"
+    path: "{{ migrid_overlay }}"
     owner: "{{ migrid_adm }}"
     group: "{{ migrid_adm }}"
     recurse: true

--- a/roles/copy_overlay_files/tasks/main.yaml
+++ b/roles/copy_overlay_files/tasks/main.yaml
@@ -8,7 +8,7 @@
     state: directory
     mode: "0755"
 
-- name: copy files from manual/au-overlay to server
+- name: copy overlay files to server
   synchronize:
     src: manual/au-overlay/{{ ansible_hostname }}/
     dest: "{{ migrid_overlay }}/{{ ansible_hostname }}/"

--- a/roles/copy_static_files/defaults/main.yml
+++ b/roles/copy_static_files/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+migrid_copy_static_files_html_src: "manual/au-overlay/{{ ansible_hostname }}/files/{{ item.file }}-{{ inventory_hostname }}.html"
+migrid_copy_static_files_dat_src:  "manual/au-overlay/{{ ansible_hostname }}/files/data_categories.json"
+migrid_copy_static_files_pdf_src:  "manual/au-overlay/{{ ansible_hostname }}/files/{{ item.file }}"

--- a/roles/copy_static_files/tasks/main.yml
+++ b/roles/copy_static_files/tasks/main.yml
@@ -43,7 +43,7 @@
 
 - name: copy static html files for migrid
   copy:
-    src: "{{ migrid_overlay }}/{{ ansible_hostname }}/files/{{ item.file }}-{{ inventory_hostname }}.html"
+    src: "{{ migrid_copy_static_files_html_src }}"
     dest: "{{ migrid_state_directory }}/{{ item.dest }}"
     owner: "{{ migrid_user }}"
     group: "{{ migrid_user }}"
@@ -67,7 +67,7 @@
 
 - name: copy gdp_home/data_categories.json for sif
   copy:
-    src: "{{ migrid_overlay }}/{{ ansible_hostname }}/files/data_categories.json"
+    src: "{{ migrid_copy_static_files_dat_src }}"
     dest: "{{ migrid_state_directory }}/gdp_home/"
     owner: "{{ migrid_user }}"
     group: "{{ migrid_user }}"
@@ -90,7 +90,7 @@
 
 - name: Copy pdf files
   copy:
-    src: "{{ migrid_overlay }}/{{ ansible_hostname }}/files/{{ item.file }}"
+    src: "{{ migrid_copy_static_files_pdf_src }}"
     dest: "{{ migrid_state_directory }}/wwwpublic/"
     owner: "{{ migrid_user }}"
     group: "{{ migrid_user }}"

--- a/roles/copy_static_files/tasks/main.yml
+++ b/roles/copy_static_files/tasks/main.yml
@@ -43,7 +43,7 @@
 
 - name: copy static html files for migrid
   copy:
-    src: manual/au-overlay/{{ ansible_hostname }}/files/{{ item.file }}-{{ inventory_hostname }}.html
+    src: "{{ migrid_overlay }}/{{ ansible_hostname }}/files/{{ item.file }}-{{ inventory_hostname }}.html"
     dest: "{{ migrid_state_directory }}/{{ item.dest }}"
     owner: "{{ migrid_user }}"
     group: "{{ migrid_user }}"
@@ -67,7 +67,7 @@
 
 - name: copy gdp_home/data_categories.json for sif
   copy:
-    src: manual/au-overlay/{{ ansible_hostname }}/files/data_categories.json
+    src: "{{ migrid_overlay }}/{{ ansible_hostname }}/files/data_categories.json"
     dest: "{{ migrid_state_directory }}/gdp_home/"
     owner: "{{ migrid_user }}"
     group: "{{ migrid_user }}"
@@ -75,7 +75,7 @@
 
 # - name: Copy index.html into wwwpublic
 #   copy:
-#     src: "manual/au-overlay/{{ ansible_hostname }}/html/index.html"
+#     src: "{{ migrid_overlay }}/{{ ansible_hostname }}/html/index.html"
 #     dest: "{{ migrid_state_directory }}/wwwpublic/"
 #     owner: "{{ migrid_user }}"
 #     group: "{{ migrid_user }}"
@@ -90,7 +90,7 @@
 
 - name: Copy pdf files
   copy:
-    src: manual/au-overlay/{{ ansible_hostname }}/files/{{ item.file }}
+    src: "{{ migrid_overlay }}/{{ ansible_hostname }}/files/{{ item.file }}"
     dest: "{{ migrid_state_directory }}/wwwpublic/"
     owner: "{{ migrid_user }}"
     group: "{{ migrid_user }}"

--- a/roles/copy_static_files/tasks/main.yml
+++ b/roles/copy_static_files/tasks/main.yml
@@ -50,18 +50,12 @@
   loop: "{{ migrid_static_html_files }}"
   when: migrid_static_html_files is defined
 
-- name: Remove old link files in wwwpublic
-  file:
-    path: "{{ migrid_state_directory }}/wwwpublic/{{ item.dest }}"
-    state: absent
-  loop: "{{ migrid_static_html_links }}"
-  when: migrid_static_html_links is defined
-
 - name: Link static html files in wwwpublic
   file:
     src: "{{ item.file }}-{{ inventory_hostname }}.html"
     dest: "{{ migrid_state_directory }}/wwwpublic/{{ item.dest }}"
     state: link
+    force: true
   loop: "{{ migrid_static_html_links }}"
   when: migrid_static_html_links is defined
 

--- a/roles/migrid_baseline/defaults/main.yml
+++ b/roles/migrid_baseline/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# this should correspond to migrid_copy_overlay_files_dest
+migrid_baseline_env_src: "{{ migrid_overlay }}/{{ ansible_hostname }}/env"

--- a/roles/migrid_baseline/tasks/main.yml
+++ b/roles/migrid_baseline/tasks/main.yml
@@ -13,6 +13,7 @@
     cmd: git config --global --add safe.directory {{ migrid_root }}
     chdir: "{{ migrid_root }}"
 
+  # fixme: code duplication: this is already done in migrid_pre_checks
 - name: Get infos on container
   community.docker.docker_container_info:
     name: migrid

--- a/roles/migrid_baseline/tasks/main.yml
+++ b/roles/migrid_baseline/tasks/main.yml
@@ -36,9 +36,9 @@
     group: "{{ migrid_adm }}"
     recurse: true
 
-- name: Set .env
+- name: Link .env in migrid_root
   file:
-    src: "{{ migrid_overlay }}/{{ ansible_hostname }}/env"
+    src: "{{ migrid_baseline_env_src }}"
     dest: "{{ migrid_root }}/.env"
     state: link
     force: false

--- a/roles/migrid_baseline/tasks/main.yml
+++ b/roles/migrid_baseline/tasks/main.yml
@@ -38,7 +38,7 @@
 
 - name: Set .env
   file:
-    src: "{{ migrid_au_overlay }}/{{ ansible_hostname }}/env"
+    src: "{{ migrid_overlay }}/{{ ansible_hostname }}/env"
     dest: "{{ migrid_root }}/.env"
     state: link
     force: false

--- a/roles/migrid_baseline/tasks/main.yml
+++ b/roles/migrid_baseline/tasks/main.yml
@@ -24,17 +24,12 @@
   when: migrid_container.exists
 
 - name: Clone docker-migrid
+  become_user: "{{ migrid_adm }}"
+  become: true
   git:
     repo: "{{ migrid_docker_repository }}"
     dest: "{{ migrid_root }}"
     version: "{{ migrid_docker_repository_version | default('master') }}"
-
-- name: Change owner on all files
-  file:
-    path: "{{ migrid_root }}"
-    owner: "{{ migrid_adm }}"
-    group: "{{ migrid_adm }}"
-    recurse: true
 
 - name: Link .env in migrid_root
   file:

--- a/roles/migrid_clean/README.md
+++ b/roles/migrid_clean/README.md
@@ -1,0 +1,5 @@
+# migrid\_clean
+
+**Attention**: This role removes the installation of migrid completely.
+
+See [defaults/main.yml](./defaults/main.yml) for configuration options.

--- a/roles/migrid_clean/defaults/main.yml
+++ b/roles/migrid_clean/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+migrid_clean_docker_prune_all: true
+migrid_clean_remove_overlay: true
+migrid_clean_remove_app_root: true

--- a/roles/migrid_clean/defaults/main.yml
+++ b/roles/migrid_clean/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 migrid_clean_docker_prune_all: true
 migrid_clean_remove_overlay: true
+migrid_clean_git_reset: false
 migrid_clean_remove_app_root: true

--- a/roles/migrid_clean/defaults/main.yml
+++ b/roles/migrid_clean/defaults/main.yml
@@ -1,5 +1,13 @@
 ---
+# remove all docker images, volumes, build cache, etc.
 migrid_clean_docker_prune_all: true
+
+# remove the {{ migrid_overlay }} directory
 migrid_clean_remove_overlay: true
+
+# run a `git reset --hard ` in the docker-migrid repo
+# this only applies if migrid_clean_remove_app_root if false
 migrid_clean_git_reset: false
+
+# Remove the whole docker-migrid repo
 migrid_clean_remove_app_root: true

--- a/roles/migrid_clean/tasks/main.yml
+++ b/roles/migrid_clean/tasks/main.yml
@@ -10,13 +10,16 @@
     networks: true
     volumes: true
     builder_cache: true
+  when: migrid_clean_docker_prune_all == true
 
 - name: Remove {{ migrid_overlay }}
   file:
     path: "{{ migrid_overlay }}"
     state: absent
+  when: migrid_clean_remove_overlay == true
 
 - name: Remove {{ migrid_root }}
   file:
     path: "{{ migrid_root }}"
     state: absent
+  when: migrid_clean_remove_app_root == true

--- a/roles/migrid_clean/tasks/main.yml
+++ b/roles/migrid_clean/tasks/main.yml
@@ -19,6 +19,17 @@
   when: migrid_clean_remove_overlay == true
 
 - name: Remove {{ migrid_root }}
+  git:
+    path: "{{ migrid_root }}"
+    repo: "{{ migrid_docker_repository }}"
+    force: true
+    update: true
+    clone: false
+  when: 
+    - migrid_clean_git_reset == true
+    - migrid_docker_repository is defined
+
+- name: Remove {{ migrid_root }}
   file:
     path: "{{ migrid_root }}"
     state: absent

--- a/roles/migrid_clean/tasks/main.yml
+++ b/roles/migrid_clean/tasks/main.yml
@@ -10,7 +10,6 @@
     networks: true
     volumes: true
     builder_cache: true
-  when: migrid_cleanup == true
 
 - name: Remove {{ migrid_overlay }}
   file:

--- a/roles/migrid_clean/tasks/main.yml
+++ b/roles/migrid_clean/tasks/main.yml
@@ -12,9 +12,9 @@
     builder_cache: true
   when: migrid_cleanup == true
 
-- name: Remove {{ migrid_au_overlay }}
+- name: Remove {{ migrid_overlay }}
   file:
-    path: "{{ migrid_au_overlay }}"
+    path: "{{ migrid_overlay }}"
     state: absent
 
 - name: Remove {{ migrid_root }}

--- a/roles/migrid_clean/tasks/main.yml
+++ b/roles/migrid_clean/tasks/main.yml
@@ -27,10 +27,12 @@
     clone: false
   when: 
     - migrid_clean_git_reset == true
+    - migrid_clean_remove_app_root == false
     - migrid_docker_repository is defined
 
 - name: Remove {{ migrid_root }}
   file:
     path: "{{ migrid_root }}"
     state: absent
-  when: migrid_clean_remove_app_root == true
+  when:
+    - migrid_clean_remove_app_root == true

--- a/roles/migrid_pre_check/tasks/main.yml
+++ b/roles/migrid_pre_check/tasks/main.yml
@@ -17,17 +17,8 @@
     file_type: any
     hidden: true
   register: found_files
-  when: migrid_bootstrap == false
-
-#note that migrid_bootstrap == "true" is a string because true it not real outside ansible
-# FIXME: bootstrap is deprecated
-- name: set matched
-  set_fact:
-    found_files:
-      matched: 1
-  when: migrid_bootstrap == "true"
 
 - name: Check state for files
   fail:
     msg: "{{migrid_root}}/state is not empty!"
-  when: found_files.matched != 0 and migrid_bootstrap == false
+  when: found_files.matched != 0

--- a/roles/stop_containers/README.md
+++ b/roles/stop_containers/README.md
@@ -1,0 +1,3 @@
+# stop\_container
+
+This role stops the mirgid application containers via docker-compose in `{{ migrid_root }}`

--- a/roles/stop_containers/tasks/main.yml
+++ b/roles/stop_containers/tasks/main.yml
@@ -1,14 +1,5 @@
 ---
 - name: Running docker-compose down
   community.docker.docker_compose:
-    project_src: "{{migrid_root}}"
+    project_src: "{{ migrid_root }}"
     state: absent
-  when: migrid_cleanup==false
-
-- name: Running docker-compose down and clean up docker images
-  community.docker.docker_compose:
-    project_src: "{{migrid_root}}"
-    remove_images: all
-    remove_volumes: true
-    state: absent
-  when: migrid_cleanup==true

--- a/roles/update_status_html/defaults/main.yml
+++ b/roles/update_status_html/defaults/main.yml
@@ -1,7 +1,15 @@
 ---
-deploy_version:
-  deploy_version: unknown
-migrid_svn_rev:
-  subversion: not used
+deploy_local_version:
+  deploy_local_version: unknown
+ansible_docker_migrid_version:
+  ansible_docker_migrid_version: unknown
+migrid_with_git:
+  WITH_GIT: not set
 migrid_git_rev:
-  migrid_git_rev: unknown
+  MIG_GIT_REV: not set
+migrid_git_branch:
+  MIG_GIT_BRANCH: not set
+migrid_perfer_python3:
+  PREFER_PYTHON3: not set
+migrid_enable_gdp:
+  ENABLE_GDP: not set

--- a/roles/update_status_html/tasks/main.yml
+++ b/roles/update_status_html/tasks/main.yml
@@ -14,18 +14,18 @@
     # fixme: hardcoded repo path, should be configurable or autodetected
     chdir: ~/git/migrid/
   register: result
-  when: migrid_update_status_deploy_version is defined
+  when: migrid_update_status_deploy_version == true
 
 - name: register tag
   set_fact:
     deploy_local_version: "{{ { 'deploy_local_version' : result.stdout } }}"
-  when: migrid_update_status_deploy_version is defined
+  when: migrid_update_status_deploy_version == true
 
 - name: get ansible-docker-migrid version
   delegate_to: localhost
   become: false
   shell:
-    cmd: ansible-galaxy collection list | grep ucphhpc.docker_migrid|cut -d" " -f2
+    cmd: "ansible-galaxy collection list | grep ucphhpc.docker_migrid|cut -d' ' -f2"
     chdir: ~
   register: result
 
@@ -41,6 +41,7 @@
 - name: get deployed migrid version
   shell:
     cmd: grep ^MIG_GIT_REV {{ migrid_root }}/.env
+  ignore_errors: true
   register: result
 
 - name: register deployed migrid version


### PR DESCRIPTION
This PR renames the `migrid_au_overlay` to `migrid_overlay` as announced. This should be the only breaking change!

Also the obsolete vars `migrid_clean` and `migrid_bootstrap` are removed.

A bunch ob role local vars are introduced to make the tasks more configurable.

Also the git clone is done directly a `migrid_adm` user, this obsoletes a chown afterwards.
The chown failed in some situations due to recursive links in mirgid app.

stop_containers now only stops containers. Removal should be done by migrid_clean imho.

migrid_clean is now more configurable and also has the possibility to only do a git reset instead of wiping everything.
This is useful, as it preserves the directory inode while redeploying.

Feedback welcome of course