### PR TITLE
Misc minor features

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: ucphhpc
 name: docker_migrid
 
 # The version of the collection. Must be compatible with semantic versioning
-version: "1.3.0"
+version: "1.4.0"
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/migrid_baseline/defaults/main.yml
+++ b/roles/migrid_baseline/defaults/main.yml
@@ -1,3 +1,7 @@
 ---
 # this should correspond to migrid_copy_overlay_files_dest
 migrid_baseline_env_src: "{{ migrid_overlay }}/{{ ansible_hostname }}/env"
+
+# Set this to the full path of a custom docker-compose file
+# eg. one in the overlay folder
+# migrid_docker_compose_custom:

--- a/roles/migrid_baseline/tasks/main.yml
+++ b/roles/migrid_baseline/tasks/main.yml
@@ -58,17 +58,9 @@
     - migrid_docker_compose_preset is defined
     - migrid_docker_compose_custom is undefined
 
-- name: Copy custom docker-compose.yml
-  ansible.builtin.copy:
-    src: "{{ migrid_docker_compose_custom }}"
-    dest: "{{ migrid_root }}/"
-    owner: "{{ migrid_adm }}"
-    group: "{{ migrid_adm }}"
-  when: migrid_docker_compose_custom is defined
-
 - name: Link to custom docker-compose.yml
   ansible.builtin.file:
-    src: "{{ migrid_root }}/{{ migrid_docker_compose_custom | basename }}"
+    src: "{{ migrid_docker_compose_custom }}"
     dest: "{{ migrid_root }}/docker-compose.yml"
     state: link
     force: true

--- a/roles/migrid_baseline/tasks/main.yml
+++ b/roles/migrid_baseline/tasks/main.yml
@@ -13,17 +13,6 @@
     cmd: git config --global --add safe.directory {{ migrid_root }}
     chdir: "{{ migrid_root }}"
 
-# fixme: code duplication: this is already done in migrid_pre_checks
-- name: Get infos on container
-  community.docker.docker_container_info:
-    name: migrid
-  register: migrid_container
-
-- name: Check if migrid container exists
-  ansible.builtin.fail:
-    msg: MiGrid container already exists, cannot continue!
-  when: migrid_container.exists
-
 - name: Clone docker-migrid
   #become_user: "{{ migrid_adm }}"
   #become: true

--- a/roles/migrid_baseline/tasks/main.yml
+++ b/roles/migrid_baseline/tasks/main.yml
@@ -2,58 +2,58 @@
 # depends on migrid-users
 ---
 - name: Create directory for MiGrid
-  file:
+  ansible.builtin.file:
     path: "{{ migrid_root }}"
     owner: "{{ migrid_adm }}"
     group: "{{ migrid_adm }}"
     state: directory
 
 - name: Set safe.directory for {{ migrid_root }}
-  command:
+  ansible.builtin.command:
     cmd: git config --global --add safe.directory {{ migrid_root }}
     chdir: "{{ migrid_root }}"
 
-  # fixme: code duplication: this is already done in migrid_pre_checks
+# fixme: code duplication: this is already done in migrid_pre_checks
 - name: Get infos on container
   community.docker.docker_container_info:
     name: migrid
   register: migrid_container
 
 - name: Check if migrid container exists
-  fail:
+  ansible.builtin.fail:
     msg: MiGrid container already exists, cannot continue!
   when: migrid_container.exists
 
 - name: Clone docker-migrid
   #become_user: "{{ migrid_adm }}"
   #become: true
-  git:
+  ansible.builtin.git:
     repo: "{{ migrid_docker_repository }}"
     dest: "{{ migrid_root }}"
     version: "{{ migrid_docker_repository_version | default('master') }}"
 
 - name: Changer owner on all files
-  file:
-    path: "{{migrid_root}}"
-    owner: "{{migrid_adm}}"
-    group: "{{migrid_adm}}"
+  ansible.builtin.file:
+    path: "{{ migrid_root }}"
+    owner: "{{ migrid_adm }}"
+    group: "{{ migrid_adm }}"
     recurse: true
 
 - name: Link .env in migrid_root
-  file:
+  ansible.builtin.file:
     src: "{{ migrid_baseline_env_src }}"
     dest: "{{ migrid_root }}/.env"
     state: link
     force: false
 
 - name: Set Dockerfile
-  file:
+  ansible.builtin.file:
     src: Dockerfile.{{ migrid_container_type }}
     dest: "{{ migrid_root }}/Dockerfile"
     state: link
 
 - name: Set docker-compose.override.yml
-  template:
+  ansible.builtin.template:
     src: docker-compose.override.yml.j2
     dest: "{{ migrid_root }}/docker-compose.override.yml"
     owner: "{{ migrid_adm }}"
@@ -61,7 +61,7 @@
   when: migrid_docker_compose_override is defined
 
 - name: Link to existing docker-compose.yml
-  file:
+  ansible.builtin.file:
     src: "{{ migrid_root }}/{{ migrid_docker_compose_preset }}"
     dest: "{{ migrid_root }}/docker-compose.yml"
     state: link
@@ -70,7 +70,7 @@
     - migrid_docker_compose_custom is undefined
 
 - name: Copy custom docker-compose.yml
-  copy:
+  ansible.builtin.copy:
     src: "{{ migrid_docker_compose_custom }}"
     dest: "{{ migrid_root }}/"
     owner: "{{ migrid_adm }}"
@@ -78,7 +78,7 @@
   when: migrid_docker_compose_custom is defined
 
 - name: Link to custom docker-compose.yml
-  file:
+  ansible.builtin.file:
     src: "{{ migrid_root }}/{{ migrid_docker_compose_custom | basename }}"
     dest: "{{ migrid_root }}/docker-compose.yml"
     state: link

--- a/roles/start_containers/defaults/main.yml
+++ b/roles/start_containers/defaults/main.yml
@@ -1,0 +1,1 @@
+migrid_start_containers_profiles: []

--- a/roles/start_containers/defaults/main.yml
+++ b/roles/start_containers/defaults/main.yml
@@ -1,1 +1,2 @@
 migrid_start_containers_profiles: []
+migrid_start_containers_recreate: "never"

--- a/roles/start_containers/tasks/main.yml
+++ b/roles/start_containers/tasks/main.yml
@@ -6,3 +6,4 @@
     project_src: "{{migrid_root}}"
     build: false
     profiles: "{{ migrid_start_containers_profiles }}"
+    recreate: "{{ migrid_start_containers_recreate }}"

--- a/roles/start_containers/tasks/main.yml
+++ b/roles/start_containers/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
-#this will start the containers in the docker-compose start fashion
+# this will start the containers in the docker-compose start fashion
 
 - name: Running docker-compose up
   community.docker.docker_compose:
     project_src: "{{migrid_root}}"
     build: false
+    profiles: "{{ migrid_start_containers_profiles }}"


### PR DESCRIPTION
This PR does:

* allow to pass profiles to the `docker compose up` call
* prevent migrid_start from recreating containers automatically
* simplifies the usage of custom docker-compose.yml
* removes the container check from migrid_baseline, see commit message