### PR TITLE
Misc 02

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: ucphhpc
 name: docker_migrid
 
 # The version of the collection. Must be compatible with semantic versioning
-version: "1.7.0"
+version: "1.8.0"
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/copy_static_files/defaults/main.yml
+++ b/roles/copy_static_files/defaults/main.yml
@@ -2,3 +2,4 @@
 migrid_copy_static_files_html_src: "manual/au-overlay/{{ ansible_hostname }}/files/{{ item.file }}-{{ inventory_hostname }}.html"
 migrid_copy_static_files_dat_src:  "manual/au-overlay/{{ ansible_hostname }}/files/data_categories.json"
 migrid_copy_static_files_pdf_src:  "manual/au-overlay/{{ ansible_hostname }}/files/{{ item.file }}"
+migrid_copy_static_files_make_clean: true

--- a/roles/copy_static_files/tasks/main.yml
+++ b/roles/copy_static_files/tasks/main.yml
@@ -34,6 +34,7 @@
 
 - name: Running docker-compose up
   community.docker.docker_compose:
+    profiles: "{{ migrid_start_containers_profiles | default(omit) }}"
     project_src: "{{ migrid_root }}"
     build: false
     recreate: always

--- a/roles/create_users/defaults/main.yml
+++ b/roles/create_users/defaults/main.yml
@@ -1,5 +1,10 @@
 ---
+# The name of the container in which the user creation shall be done
 migrid_create_users_container: migrid
 
-# A liste of users which shall be created
+# The user inside the docker container as which the user creation
+# shall be done
+migrid_create_users_container_user: mig
+
+# A list of users which shall be created
 migrid_create_users: []

--- a/roles/create_users/tasks/main.yml
+++ b/roles/create_users/tasks/main.yml
@@ -13,4 +13,5 @@
       - "{{ item.comment | default ('created by Ansible') }}"
       - "{{ item.password }}"
     chdir: "/home/mig/mig/server"
+    user: "{{ migrid_create_users_container_user }}"
   loop: "{{ migrid_create_users }}"

--- a/roles/migrid_baseline/defaults/main.yml
+++ b/roles/migrid_baseline/defaults/main.yml
@@ -5,3 +5,6 @@ migrid_baseline_env_src: "{{ migrid_overlay }}/{{ ansible_hostname }}/env"
 # Set this to the full path of a custom docker-compose file
 # eg. one in the overlay folder
 # migrid_docker_compose_custom:
+
+migrid_baseline_chown: true
+migrid_baseline_chown_follow_symlinks: true

--- a/roles/migrid_baseline/tasks/main.yml
+++ b/roles/migrid_baseline/tasks/main.yml
@@ -20,6 +20,7 @@
     repo: "{{ migrid_docker_repository }}"
     dest: "{{ migrid_root }}"
     version: "{{ migrid_docker_repository_version | default('master') }}"
+    force: true
 
 - name: Changer owner on all files
   ansible.builtin.file:

--- a/roles/migrid_baseline/tasks/main.yml
+++ b/roles/migrid_baseline/tasks/main.yml
@@ -21,6 +21,15 @@
     dest: "{{ migrid_root }}"
     version: "{{ migrid_docker_repository_version | default('master') }}"
 
+- name: Changer owner on all files
+  ansible.builtin.file:
+    path: "{{ migrid_root }}"
+    owner: "{{ migrid_adm }}"
+    group: "{{ migrid_adm }}"
+    recurse: true
+    follow: "{{ migrid_baseline_chown_follow_symlinks }}"
+  when: migrid_baseline_chown
+
 - name: Link .env in migrid_root
   ansible.builtin.file:
     src: "{{ migrid_baseline_env_src }}"

--- a/roles/migrid_clean/tasks/main.yml
+++ b/roles/migrid_clean/tasks/main.yml
@@ -18,7 +18,7 @@
     state: absent
   when: migrid_clean_remove_overlay == true
 
-- name: Remove {{ migrid_root }}
+- name: Reset git repository {{ migrid_root }}
   git:
     dest: "{{ migrid_root }}"
     repo: "{{ migrid_docker_repository }}"

--- a/roles/migrid_users/tasks/main.yml
+++ b/roles/migrid_users/tasks/main.yml
@@ -12,7 +12,6 @@
     comment: MiGrid User
     group: "{{ migrid_adm }}"
     shell: /bin/bash
-    # fixme: hardcoded userids are evil
     uid: "{{ migrid_adm_uid }}"
     password_lock: true
 


### PR DESCRIPTION
This PR aligns with the Makefile in latest docker-migrid repo and adds a option to skip the `make clean`.

It also removes the recursive chown after cloning the repo (again) since this leads to several sideeffects like

* failing if the directory is not freshly cloned because of the recursive symlinks in docker-migrid
* changing ownership of files in /mig and /state which should only be managed by migrid itself

This results in the roles not being idempotent and since we're not deleting everything and building from scratch every deployment at KU we'd like Ansible not to change all those files at once.

@Bjarke42 if that breaks your runs, we should figure out why and maybe find another solution?