### PR TITLE
added role setup_prerequisites

### DIFF
--- a/roles/create_users/README.md
+++ b/roles/create_users/README.md
@@ -1,13 +1,11 @@
-Role Name
-=========
+# Migrid create\_users
 
 This roles creates static users inside a MiGrid installation.
 
 It works by calling the usercreate.py inside a running migrid container similar to the way the docker-entry.sh does.
 Eg. `createuser.py [OPTIONS] [FULL_NAME ORGANIZATION STATE COUNTRY EMAIL COMMENT PASSWORD]`
 
-Role Variables
---------------
+# Role Variables
 
 ```
 migrid_create_users:

--- a/roles/migrid_baseline/tasks/main.yml
+++ b/roles/migrid_baseline/tasks/main.yml
@@ -52,14 +52,18 @@
     group: "{{ migrid_adm }}"
   when: migrid_docker_compose_override is defined
 
+- name: check for docker-compose file
+  assert:
+    that:
+      - migrid_docker_compose_preset is defined or migrid_docker_compose_custom is defined
+    fail_msg: "Either migrid_docker_compose_preset or migrid_docker_compose_custom must be specified"
+
 - name: Link to existing docker-compose.yml
   ansible.builtin.file:
     src: "{{ migrid_root }}/{{ migrid_docker_compose_preset }}"
     dest: "{{ migrid_root }}/docker-compose.yml"
     state: link
-  when:
-    - migrid_docker_compose_preset is defined
-    - migrid_docker_compose_custom is undefined
+  when: migrid_docker_compose_preset is defined
 
 - name: Link to custom docker-compose.yml
   ansible.builtin.file:
@@ -67,4 +71,6 @@
     dest: "{{ migrid_root }}/docker-compose.yml"
     state: link
     force: true
-  when: migrid_docker_compose_custom is defined
+  when:
+    - migrid_docker_compose_custom is defined
+    - migrid_docker_compose_preset is undefined

--- a/roles/setup_prerequisites/README.md
+++ b/roles/setup_prerequisites/README.md
@@ -1,0 +1,5 @@
+# Migrid setup\_prerequisites
+
+This roles install dependencies and makes some basic confiugration on the host running docker-migrid.
+
+**Be aware** that the installtion of Docker/Podman is not done in this role.

--- a/roles/setup_prerequisites/defaults/main.yml
+++ b/roles/setup_prerequisites/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+migrid_redhat_prerequisites:
+  - git
+  - rsync

--- a/roles/setup_prerequisites/tasks/main.yml
+++ b/roles/setup_prerequisites/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: install RedHat prerequisits
+  yum:
+    name: "{{ migrid_redhat_prerequisites }}"
+    state: present
+  when: ansible_os_family == "RedHat"

--- a/roles/setup_vars/defaults/main.yml
+++ b/roles/setup_vars/defaults/main.yml
@@ -1,3 +1,1 @@
 ---
-migrid_redhat_prerequisites:
-  - git

--- a/roles/setup_vars/tasks/main.yml
+++ b/roles/setup_vars/tasks/main.yml
@@ -17,17 +17,3 @@
   set_fact:
     migrid_cipher_directory: /mnt/{{migrid_lustre_mount_point}}/{{ansible_hostname}}
   when: migrid_encrypt_state==true
-
-# - name: debug
-#   debug:
-#     msg:  "migrid state dir now {{migrid_state_directory}}"
-
-# - name: debug2
-#   debug:
-#     msg: "migrid cipher dir {{migrid_cipher_directory}}"
-
-- name: install RedHat prerequisits
-  yum:
-    name: "{{ migrid_redhat_prerequisites }}"
-    state: present
-  when: ansible_os_family == "RedHat"


### PR DESCRIPTION
This PR takes the installation of prerequisites to a seperate role. This was by accident in the setup_vars role.

Also it ensures that the variable `migrid_docker_compose_preset` take precedence over `migrid_docker_compose_custom` 