### PR TITLE
move make clean to migrid_clean role

### DIFF
--- a/roles/copy_static_files/tasks/main.yml
+++ b/roles/copy_static_files/tasks/main.yml
@@ -6,11 +6,6 @@
 # ---------------------------------------------------------------
 # This should be a seperate build role
 # ---------------------------------------------------------------
-- name: Run make clean to remove anything already built
-  shell:
-    cmd: make clean > make-clean.log 2>&1
-    chdir: "{{ migrid_root }}"
-
 #fixme: why does the build happen in copy_static_files
 - name: Run make to build MiGrid
   shell:

--- a/roles/migrid_clean/defaults/main.yml
+++ b/roles/migrid_clean/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+# run `make clean` inside the docker-migrid repo
+migrid_make_clean: true
+
 # remove all docker images, volumes, build cache, etc.
 migrid_clean_docker_prune_all: true
 

--- a/roles/migrid_clean/tasks/main.yml
+++ b/roles/migrid_clean/tasks/main.yml
@@ -1,6 +1,13 @@
 # clean up directories before doing anything is a good thing.. aah the fresh smell of clean :)
 ---
-# fixme: this should have checks as it can mean dataloss and downtime
+- name: Run make clean to remove anything already built
+  shell:
+    cmd: make clean > make-clean.log 2>&1
+    chdir: "{{ migrid_root }}"
+  when:
+    - migrid_clean_remove_app_root == false
+    - migrid_make_clean == true
+
 - name: Prune everything in docker
   community.docker.docker_prune:
     containers: true


### PR DESCRIPTION
This PR moves the make clean execution to the migrid_clean role where it might fit better.

This should avoid the deletion of already deployed certs and allows better control over when the deletion happens.