### PR TITLE
changed enabled to false

### DIFF
--- a/roles/migrid_logrotate/tasks/main.yml
+++ b/roles/migrid_logrotate/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: Enable logrotate (Debian)
   systemd:
     name: logrotate
-    enabled: true
+    enabled: false
     state: started
   when: ansible_os_family == "Debian"
 

--- a/roles/promtail_migrid/tasks/main.yml
+++ b/roles/promtail_migrid/tasks/main.yml
@@ -27,5 +27,5 @@
 - name: Enable Promtail
   systemd:
     name: promtail
-    enabled: true
+    enabled: false
     state: stopped


### PR DESCRIPTION
Its the start-migrid and stop-migrid that manages the logging service, they should never be started on bootup. Now changed so they will not start during bootup. 