### PR TITLE
copy_cert_files: link to external certs dir

### DIFF
--- a/roles/copy_cert_files/tasks/main.yml
+++ b/roles/copy_cert_files/tasks/main.yml
@@ -2,6 +2,15 @@
 # copy cert files into migrid_root directory
 # depends on migrid-baseline
 
+# If certs is set to external directory, link it into the docker-migrid directory
+- name: Link cert to external directory
+
+  file:
+    src: "{{ migrid_certs }}"
+    dest: "{{ migrid_root }}/certs"
+    state: link
+  when: not migrid_certs is search(migrid_root)
+
 - name: Create directoris for certificates
   file:
     path: "{{ migrid_certs }}/MiG/*.{{ migrid_copy_cert_files_domain }}"


### PR DESCRIPTION
This PR adds a task to link to an external certs directory. It is only executed if `migrid_certs` is not within `migrid_root`.

We use this cause we have other Ansible roles providing certificates before migrid is deployed and we like to keep external provided config outside of the docker-migrid repo directory.