### PR TITLE
move decrypt mountpoint away from migrid_root directory

### DIFF
--- a/examples/group_vars/all
+++ b/examples/group_vars/all
@@ -9,6 +9,7 @@
 
 #migrid settings
 migrid_root: /opt/migrid/docker-migrid      # root directory where all the migrid files recides on the server
+migrid_decrypted_directory: /opt/migrid     # The directory outside migrid_root where decrypted mountpoint is
 ##migrid_auoverlay
 migrid_overlay: /opt/migrid/au-overlay   # the au overlay files that are placed ontop of files pulled from docker-migrid repository
 migrid_certs: "{{ migrid_root }}/certs"     # directory where all certificates recides

--- a/roles/connect_lustre/tasks/main.yml
+++ b/roles/connect_lustre/tasks/main.yml
@@ -46,7 +46,6 @@
     mode: "0755"
   when: migrid_encrypt_state==true
 
-# non encryption stuff
 # this is for humans only!
 # DO NOT USE THIS FOR PROGRAMS, use migrid_state_directory
 - name: Create link from migrid state to migrid_connect_lustre_state_link ({{ migrid_connect_lustre_state_link }})
@@ -54,4 +53,3 @@
     src: "{{ migrid_state_directory }}"
     dest: "{{ migrid_root }}/{{ migrid_connect_lustre_state_link }}"
     state: link
-  when: migrid_encrypt_state==false

--- a/roles/setup_encrypt_state/tasks/main.yml
+++ b/roles/setup_encrypt_state/tasks/main.yml
@@ -11,6 +11,7 @@
     msg: "{{migrid_cipher_directory}}/gocryptfs.conf exist skipping create fs"
   when: migrid_encrypt_state==true and st.stat.exists==true
 
+# This will only run if gocryptfs is not configured
 - name: Import encryption task if needed
   import_tasks:
     file: encrypt.yml

--- a/roles/setup_vars/tasks/main.yml
+++ b/roles/setup_vars/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Setup state directory pointer for encryption
   set_fact:
-    migrid_state_directory: "{{migrid_root}}/{{migrid_decrypt_dir}}"
+    migrid_state_directory: "{{migrid_decrypted_directory}}/{{migrid_decrypt_dir}}"
   when: migrid_encrypt_state==true
 
 - name: Set cipher directory for goencrypt


### PR DESCRIPTION
Its necessary not to have a mountpoint in the migrid_root directory because then the make will begin to backup stuff from the directory, which is not desired.
Changed and tested.