### PR TITLE
create_static_users: bugfixing create options

### DIFF
--- a/roles/create_static_users/README.md
+++ b/roles/create_static_users/README.md
@@ -11,7 +11,7 @@ Eg. `createuser.py [OPTIONS] [FULL_NAME ORGANIZATION STATE COUNTRY EMAIL COMMENT
 
 ```
 migrid_create_static_users:
- - options: -r # (this is the default, overwrite the user information)
+ - options: -r # override the user infos an password
    full_name: Foo Bar
    organization: Org42
    state: Baz
@@ -22,7 +22,7 @@ migrid_create_static_users:
 
 see also [defaults/main.yml](./defaults/main.yml)
 
-If you don't want the user to be overwritten you have to set `options: ""`.
+If `-r` is not given and the user already exists, this role will report an error.
 
 Dependencies
 ------------

--- a/roles/create_static_users/tasks/main.yml
+++ b/roles/create_static_users/tasks/main.yml
@@ -2,16 +2,7 @@
 - name: run create user command in container
   community.docker.docker_container_exec:
     container: "{{ migrid_create_users_container }}"
-    argv:
-      - "./createuser.py"
-      - "-v {{ item.options | default('-r') }}"
-      - "{{ item.full_name}}"
-      - "{{ item.organization }}"
-      - "{{ item.state }}"
-      - "{{ item.country }}"
-      - "{{ item.email }}"
-      - "{{ item.comment | default ('created by Ansible') }}"
-      - "{{ item.password }}"
+    command: "./createuser.py -v {{ item.options | default('') }} {{ item.full_name}} {{ item.organization }} {{ item.state }} {{ item.country }} {{ item.email }} '{{ item.comment | default ('created by Ansible') }}' {{ item.password }}"
     chdir: "/home/mig/mig/server"
     user: "{{ migrid_create_users_container_user }}"
   loop: "{{ migrid_create_users }}"


### PR DESCRIPTION
Fixes the static user creation command which was buggy when `options` were given.

Also changes the default behavior to not overwrite users