### PR TITLE
changes for sif

### DIFF
--- a/roles/copy_static_files/tasks/main.yml
+++ b/roles/copy_static_files/tasks/main.yml
@@ -64,21 +64,6 @@
   loop: "{{ migrid_static_html_links }}"
   when: migrid_static_html_links is defined
 
-- name: copy gdp_home/data_categories.json for sif
-  copy:
-    src: "{{ migrid_copy_static_files_dat_src }}"
-    dest: "{{ migrid_state_directory }}/gdp_home/"
-    owner: "{{ migrid_user }}"
-    group: "{{ migrid_user }}"
-  when: migrid_base_type == "sif"
-
-# - name: Copy index.html into wwwpublic
-#   copy:
-#     src: "{{ migrid_overlay }}/{{ ansible_hostname }}/html/index.html"
-#     dest: "{{ migrid_state_directory }}/wwwpublic/"
-#     owner: "{{ migrid_user }}"
-#     group: "{{ migrid_user }}"
-#
 - name: Copy dhparams.pem into certs/
   copy:
     src: "{{ migrid_root }}/httpd/MiG-certificates/dhparams.pem"

--- a/roles/migrid_email_notifications/tasks/notifications.yml
+++ b/roles/migrid_email_notifications/tasks/notifications.yml
@@ -6,6 +6,8 @@
   synchronize:
     src: "{{ migrid_copy_email_notifications_dir }}/"
     dest: "{{ migrid_state_directory }}/gdp_home/"
+    owner: false
+    group: false
 
 - name: Changer owner on all files
   file:


### PR DESCRIPTION
copy_static_files role had data_categories.json copy for sif installations, which is now handled by migrid_email_notifications role.

copy index.html is also remove because that has been move elsewhere a long time ago.

in role migrid_email_notifications, it seems that some environments will require owner, and group set to false for synchronization, were as some environments don't care. strange, but now added. 